### PR TITLE
monkey: fix handling http requset crash

### DIFF
--- a/lib/monkey/mk_server/mk_http.c
+++ b/lib/monkey/mk_server/mk_http.c
@@ -67,7 +67,7 @@ void mk_http_request_init(struct mk_http_session *session,
 
     request->port = 0;
     request->status = MK_TRUE;
-    request->uri.data = NULL;
+    request->uri.data = "";
     request->method = MK_METHOD_UNKNOWN;
     request->protocol = MK_HTTP_PROTOCOL_UNKNOWN;
     request->connection.len = -1;


### PR DESCRIPTION
This patch fix a problem when upload zip exceeding a certain size.
The flb_realloc in http_conn_event (http_conn.c:56)  free request->uri.data memory, fluent-bit crashed. 
Like issue #5532.

the patch have been tested using tools valgrind.

Signed-off-by:  Junzeng junzeng@mails.ccnu.edu.cn

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
